### PR TITLE
Extract jvm version from openjdk vulnerabilities group

### DIFF
--- a/cvereporter/fetch_vulnerabilities.py
+++ b/cvereporter/fetch_vulnerabilities.py
@@ -82,7 +82,6 @@ def parse_to_dict(resp_text: str, date: str) -> list[dict]:
     column_headers = []
     # fetch CVE data from first td in each row
     for row in rows:
-
         # find the versions in the first row
         header = row.find("th")
         versions = []
@@ -94,21 +93,22 @@ def parse_to_dict(resp_text: str, date: str) -> list[dict]:
                     versions.append(score.find_next_sibling("th").text)
                     score = score.find_next_sibling("th")
             # extract table column headers
-            if("CVE ID" in header.text):
+            if "CVE ID" in header.text:
                 current_column_header = header
                 while current_column_header is not None:
                     column_headers.append(current_column_header.text)
-                    current_column_header = current_column_header.find_next_sibling("th")
+                    current_column_header = current_column_header.find_next_sibling(
+                        "th"
+                    )
             print(column_headers)
-                
 
         cve = row.find("td")
         affected_major_versions = []
         index = 0
         for column in row.find_all("td"):
-            if(column.text == "•"):
+            if column.text == "•":
                 affected_major_versions.append(int(column_headers[index]))
-            index +=1
+            index += 1
         if cve is not None:
             id = cve.text
             if cve.text == "None":
@@ -118,14 +118,19 @@ def parse_to_dict(resp_text: str, date: str) -> list[dict]:
             component = componentsTD.text.replace("\n", "")
             affected_versions = []
             for version in extracted_affected:
-                if "." in version and int(version[0:version.index(".")]) in affected_major_versions:
+                if (
+                    "." in version
+                    and int(version[0 : version.index(".")]) in affected_major_versions
+                ):
                     affected_versions.append(version)
 
-                elif "u" in version and int(version[0:version.index("u")]) in affected_major_versions:
+                elif (
+                    "u" in version
+                    and int(version[0 : version.index("u")]) in affected_major_versions
+                ):
                     affected_versions.append(version)
                 elif version.isnumeric() and int(version) in affected_major_versions:
                     affected_versions.append(version)
-
 
             parsed_data = {}
             parsed_data["id"] = id
@@ -144,9 +149,9 @@ def dict_to_vulns(dicts: list[dict]) -> list[Vulnerability]:
     for parsed_data in dicts:
         affects = BomTarget(ref=parsed_data["component"])
         for v in parsed_data["affected"]:
-        # todo: we assume that the affected versions are an intersection between the dots on the grid
-        # and the list of all affected versions. This may not necessarily be true, if there are multiple cves
-        # one that affects one minor version and another that affects another, within the same major version
+            # todo: we assume that the affected versions are an intersection between the dots on the grid
+            # and the list of all affected versions. This may not necessarily be true, if there are multiple cves
+            # one that affects one minor version and another that affects another, within the same major version
             affects.versions.add(v)
         vuln = Vulnerability(
             id=parsed_data["id"],

--- a/cvereporter/fetch_vulnerabilities.py
+++ b/cvereporter/fetch_vulnerabilities.py
@@ -170,6 +170,15 @@ def dict_to_vulns(dicts: list[dict]) -> list[Vulnerability]:
     return vulnerabilities
 
 
+'''
+We assume the text for the affected versions is in a block like:
+
+"The following vulnerabilities in OpenJDK source code were fixed in this release. 
+The affected versions are 12, 11.0.2, 8u202, 7u211, and earlier. 
+We recommend that you upgrade as soon as possible."
+
+'''
+
 def extract_affected(header_string: str) -> list[str]:
     header_string = header_string.replace("\r", "").replace("\n", " ")
     affected = []

--- a/cvereporter/fetch_vulnerabilities.py
+++ b/cvereporter/fetch_vulnerabilities.py
@@ -137,10 +137,7 @@ def parse_to_dict(resp_text: str, date: str) -> list[dict]:
                     affected_versions.append(version)
             print("affected versions")
             print(affected_versions)
-            for version in versions:
-                versionCheck = versionCheck.find_next_sibling("td")
-                if versionCheck.text == "•":
-                    affected_versions.append(int(version))
+
 
             parsed_data = {}
             parsed_data["id"] = id

--- a/cvereporter/nist_enhance.py
+++ b/cvereporter/nist_enhance.py
@@ -102,7 +102,10 @@ def enhance(vulns: list[Vulnerability]):
             )
             vuln.ratings.add(vr)
         vuln.description = relevant["description"]
-        for affects in vuln.affects:
-            for ver in relevant["versions"]:
-                affects.versions.add(ver)
+        # for now - we use ojvg's version extraction
+        extract_versions_from_nist = False
+        if extract_versions_from_nist:
+            for affects in vuln.affects:
+                for ver in relevant["versions"]:
+                    affects.versions.add(ver)
         # print(vuln)

--- a/cvereporter/nist_enhance.py
+++ b/cvereporter/nist_enhance.py
@@ -102,7 +102,9 @@ def enhance(vulns: list[Vulnerability]):
             )
             vuln.ratings.add(vr)
         vuln.description = relevant["description"]
-        # for now - we use ojvg's version extraction
+        # for now - we use versions we extract when we download from OpenJDK Vulnerability group
+        # this version extraction is tied to the Oracle JDKs which might not map directly to openjdk versions
+        # that approach also has limitations: we have to do a bit of guesswork mapping cves to versions
         extract_versions_from_nist = False
         if extract_versions_from_nist:
             for affects in vuln.affects:

--- a/ojvg_download.py
+++ b/ojvg_download.py
@@ -7,7 +7,7 @@ a brute force ojvg downloader which iterates through all dates from 1 jan 2019 (
 It downloads all the vulnerability reports as html files to the `data` directory and saves the relevant data in `data/ojvg_summary.json`
 """
 start_date = date(2019, 1, 1)
-end_date = date(2024, 2, 4)
+end_date = date.today()
 current_date = start_date
 responses = []
 while current_date < end_date:

--- a/ojvg_download.py
+++ b/ojvg_download.py
@@ -11,7 +11,6 @@ end_date = date.today()
 current_date = start_date
 responses = []
 while current_date < end_date:
-
     date_str = current_date.strftime("%Y-%m-%d")
     print(date_str)
     resp = fetch_vulnerabilities.fetch_dicts(date_str)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -20,15 +20,10 @@ def test_fetch():
 def test_parse_to_dict():
     with open("tests/data/open_jvg_dump_2023-01-17.html","r") as data:
         vulns = fetch_vulnerabilities.parse_to_dict(data, "2023-01-17")
-
-        assert(len(vulns)==3)
-        #todo: do some better assertions on the actual vulnerability contents here
-        assert(vulns[0].id == "CVE-2023-21835")
-        assert(list(vulns[0].affects)[0].ref == "security-libs/javax.net.ssl")
-        assert(vulns[1].id == "CVE-2023-21830")
-        assert(list(vulns[1].affects)[0].ref == "other-libs")
-        assert(vulns[2].id == "CVE-2023-21843")
-        assert(list(vulns[2].affects)[0].ref == "client-libs/javax.sound")
+        print(vulns)
+        for cve in vulns:
+            if cve["id"] == "CVE-2023-21830":
+                assert(len(cve["affected"]) == 2)
 
 def test_nist_parse():
     with open("tests/data/nist_CVE-2023-21830.json", "r") as file_data:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -15,6 +15,7 @@ def test_fetch():
         assert(list(vulns[1].affects)[0].ref == "other-libs")
         assert(vulns[2].id == "CVE-2023-21843")
         assert(list(vulns[2].affects)[0].ref == "client-libs/javax.sound")
+        assert(len(list(vulns[1].affects)[0].versions)==2)
 
 
 def test_parse_to_dict():

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,9 +1,26 @@
 from cvereporter import fetch_vulnerabilities, nist_enhance
 import json
 
+# to run just one test: python3 -m pytest -v -k test_fetch -s (in this case, runs "test_fetch")
 def test_fetch():
     with open("tests/data/open_jvg_dump_2023-01-17.html","r") as data:
         vulns = fetch_vulnerabilities.parse_to_cyclone(data, "2023-01-17")
+
+        print(vulns)
+        assert(len(vulns)==3)
+        #todo: do some better assertions on the actual vulnerability contents here
+        assert(vulns[0].id == "CVE-2023-21835")
+        assert(list(vulns[0].affects)[0].ref == "security-libs/javax.net.ssl")
+        assert(vulns[1].id == "CVE-2023-21830")
+        assert(list(vulns[1].affects)[0].ref == "other-libs")
+        assert(vulns[2].id == "CVE-2023-21843")
+        assert(list(vulns[2].affects)[0].ref == "client-libs/javax.sound")
+
+
+def test_parse_to_dict():
+    with open("tests/data/open_jvg_dump_2023-01-17.html","r") as data:
+        vulns = fetch_vulnerabilities.parse_to_dict(data, "2023-01-17")
+
         assert(len(vulns)==3)
         #todo: do some better assertions on the actual vulnerability contents here
         assert(vulns[0].id == "CVE-2023-21835")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -2,7 +2,7 @@ from cvereporter import fetch_vulnerabilities, nist_enhance
 import json
 
 
-# to run just one test: python3 -m pytest -v -k test_fetch -s (in this case, runs "test_fetch")
+# To run a single test: python3 -m pytest -v -k test_fetch -s (in this case, runs "test_fetch")
 def test_fetch():
     with open("tests/data/open_jvg_dump_2023-01-17.html", "r") as data:
         vulns = fetch_vulnerabilities.parse_to_cyclone(data, "2023-01-17")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,30 +1,32 @@
 from cvereporter import fetch_vulnerabilities, nist_enhance
 import json
 
+
 # to run just one test: python3 -m pytest -v -k test_fetch -s (in this case, runs "test_fetch")
 def test_fetch():
-    with open("tests/data/open_jvg_dump_2023-01-17.html","r") as data:
+    with open("tests/data/open_jvg_dump_2023-01-17.html", "r") as data:
         vulns = fetch_vulnerabilities.parse_to_cyclone(data, "2023-01-17")
 
         print(vulns)
-        assert(len(vulns)==3)
-        #todo: do some better assertions on the actual vulnerability contents here
-        assert(vulns[0].id == "CVE-2023-21835")
-        assert(list(vulns[0].affects)[0].ref == "security-libs/javax.net.ssl")
-        assert(vulns[1].id == "CVE-2023-21830")
-        assert(list(vulns[1].affects)[0].ref == "other-libs")
-        assert(vulns[2].id == "CVE-2023-21843")
-        assert(list(vulns[2].affects)[0].ref == "client-libs/javax.sound")
-        assert(len(list(vulns[1].affects)[0].versions)==2)
+        assert len(vulns) == 3
+        # todo: do some better assertions on the actual vulnerability contents here
+        assert vulns[0].id == "CVE-2023-21835"
+        assert list(vulns[0].affects)[0].ref == "security-libs/javax.net.ssl"
+        assert vulns[1].id == "CVE-2023-21830"
+        assert list(vulns[1].affects)[0].ref == "other-libs"
+        assert vulns[2].id == "CVE-2023-21843"
+        assert list(vulns[2].affects)[0].ref == "client-libs/javax.sound"
+        assert len(list(vulns[1].affects)[0].versions) == 2
 
 
 def test_parse_to_dict():
-    with open("tests/data/open_jvg_dump_2023-01-17.html","r") as data:
+    with open("tests/data/open_jvg_dump_2023-01-17.html", "r") as data:
         vulns = fetch_vulnerabilities.parse_to_dict(data, "2023-01-17")
         print(vulns)
         for cve in vulns:
             if cve["id"] == "CVE-2023-21830":
-                assert(len(cve["affected"]) == 2)
+                assert len(cve["affected"]) == 2
+
 
 def test_nist_parse():
     with open("tests/data/nist_CVE-2023-21830.json", "r") as file_data:
@@ -32,8 +34,8 @@ def test_nist_parse():
         relevant_parts = nist_enhance.extract_relevant_parts(nist_data)
         rtg = relevant_parts["ratings"][0]
         desc = relevant_parts["description"]
-        assert(rtg["source"] == 'secalert_us@oracle.com')
-        assert(rtg["score"] == 5.3)
-        assert(rtg["severity"] == "MEDIUM")
-        assert(rtg["vector"] == "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N")
-        assert(len(relevant_parts["versions"])==4)
+        assert rtg["source"] == "secalert_us@oracle.com"
+        assert rtg["score"] == 5.3
+        assert rtg["severity"] == "MEDIUM"
+        assert rtg["vector"] == "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N"
+        assert len(relevant_parts["versions"]) == 4


### PR DESCRIPTION
Two steps required here:

1) Extract versions mentioned in the report (already done).
2) intersect list of all versions with major versions reported in the dot matrix for each cve..

Also includes unit test  coverage for this version extraction. Disables the NIST version extraction.