### PR TITLE
Add github actions permissions scheme for semgrep differential scan

### DIFF
--- a/.github/workflows/semgrep_diff.yml
+++ b/.github/workflows/semgrep_diff.yml
@@ -1,8 +1,25 @@
+# ********************************************************************************
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made
+# available under the terms of the Apache Software License 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************
+
 ---
 name: Semgrep Differential Scan
 on:
   pull_request:
 
+permissions:
+  contents: read
+  statuses: write
+  
 jobs:
   semgrep-diff:
     uses: adoptium/.github/.github/workflows/semgrep_diff.yml@main


### PR DESCRIPTION
Add the now required github actions permissions scheme for the Semgrep action.