### PR TITLE
Add mypy for typechecking and vdr validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,5 +39,8 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
+    - name: Type check with mypy
+      run: python3 -m mypy
+
     - name: Test with pytest
       run: python3 -m pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
     - name: Type check with mypy
-      run: python3 -m mypy
+      run: python3 -m mypy .
 
     - name: Test with pytest
       run: python3 -m pytest

--- a/cvereporter/nist_enhance.py
+++ b/cvereporter/nist_enhance.py
@@ -51,7 +51,7 @@ def fetch_nist(url: str, id: str) -> Optional[dict]:
         """
     else:
         data = nist_resp.json()
-        with open(file_location) as dest:
+        with open(file_location, "w") as dest:
             json.dump({"url": url, "data": data}, dest, indent=True)
     return data
 

--- a/cvereporter/nist_enhance.py
+++ b/cvereporter/nist_enhance.py
@@ -5,6 +5,8 @@ from cyclonedx.model.vulnerability import (
     VulnerabilitySource,
     VulnerabilityScoreSource,
     VulnerabilityRating,
+    BomTarget,
+    BomTargetVersionRange,
 )
 import requests
 import json
@@ -17,6 +19,14 @@ this file has the utilities for downloading data about cves from NIST and updati
 
 
 def fetch_nist(url: str, id: str) -> Optional[dict]:
+    file_location = "data/nist_" + id + ".json"
+    try:
+        with open(file_location, "r") as the_file:
+            data = json.load(the_file)["data"]
+            print("resolved from cache " + url)
+            return data
+    except:
+        print("unable to find pre-fetched nist response, actually performing fetch.")
     data = None
     nist_resp = None
     if (
@@ -41,7 +51,7 @@ def fetch_nist(url: str, id: str) -> Optional[dict]:
         """
     else:
         data = nist_resp.json()
-        with open("data/nist_" + id + ".json", "w") as dest:
+        with open(file_location) as dest:
             json.dump({"url": url, "data": data}, dest, indent=True)
     return data
 
@@ -131,5 +141,5 @@ def enhance(vulns: list[Vulnerability]):
         if extract_versions_from_nist:
             for affects in vuln.affects:
                 for ver in relevant["versions"]:
-                    affects.versions.add(ver)
+                    affects.versions.add(BomTargetVersionRange(version=ver))
         # print(vuln)

--- a/cvereporter/report.py
+++ b/cvereporter/report.py
@@ -1,6 +1,6 @@
 from cyclonedx.factory.license import LicenseFactory
 from cyclonedx.model import XsUri, ExternalReferenceType
-from cyclonedx.model.bom import Bom
+from cyclonedx.model.bom import Bom, OrganizationalEntity
 from cyclonedx.model.component import Component, ComponentType, ExternalReference
 from cyclonedx.model.impact_analysis import ImpactAnalysisAffectedStatus
 from cyclonedx.model.vulnerability import (
@@ -28,7 +28,10 @@ def get_base_bom() -> Bom:
         type=ComponentType.APPLICATION,
         licenses=[lc_factory.make_from_string("GPL-2.0 WITH Classpath-exception-2.0")],
         bom_ref="temurin-vdr",
-        supplier="Eclipse foundation",
+        supplier=OrganizationalEntity(
+            name="Eclipse Foundation",
+            urls=[XsUri("https://www.eclipse.org/org/foundation/")],
+        ),
         external_references=[
             ExternalReference(
                 type=ExternalReferenceType.DISTRIBUTION,

--- a/cvereporter/report.py
+++ b/cvereporter/report.py
@@ -113,6 +113,3 @@ def sbom_creation_test():
     serialized_json = my_json_outputter.output_as_string(indent=2)
     print("\n\n\n")
     print(serialized_json)
-
-
-# validate_bom(open("vdr.json","r").read())

--- a/ojvg_download.py
+++ b/ojvg_download.py
@@ -7,12 +7,13 @@ import time
 a brute force ojvg downloader which iterates through all dates from 1 jan 2019 (month reports start) to something close to the present day (end_date).
 It downloads all the vulnerability reports as html files to the `data` directory and saves the relevant data in `data/ojvg_summary.json`
 """
-start_date = date(2024, 4, 17)
+start_date = date(2024, 7, 17)
 end_date = date.today()
 current_date = start_date
 responses = []
 # hard code this, to avoid excessive api calls. Assume no backdated advisories will be published, only fetch every day for dates after last report.
 list_of_dates = [
+    "2024-07-16",
     "2024-04-16",
     "2024-01-16",
     "2023-10-17",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 beautifulsoup4==4.12.3
 cyclonedx-python-lib===7.5.1
+cyclonedx-python-lib[validation]
 requests==2.32.3
+mypy
+types-requests
+types-beautifulsoup4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4==4.12.3
-cyclonedx-python-lib===7.5.1
-cyclonedx-python-lib[validation]
+cyclonedx-python-lib==7.5.1
+cyclonedx-python-lib[validation]==7.5.1
 requests==2.32.3
-mypy
-types-requests
-types-beautifulsoup4
+mypy==1.11.1
+types-requests==2.32.0.20240712
+types-beautifulsoup4==4.12.0.20240511


### PR DESCRIPTION
resolves #43 

Summary of changes:
* mypy is now used to validate types
* the generated vdr is passed in through the python library's built in validator
* pick up locally cached NIST responses for much faster local development

I manually validated that the generated vdr is valid according to https://cyclonedx.github.io/cyclonedx-web-tool/