### PR TITLE
Add GitHub Actions workflow to query Dependency-Track

### DIFF
--- a/.github/workflows/query-dtrack.yml
+++ b/.github/workflows/query-dtrack.yml
@@ -1,0 +1,22 @@
+#querying from dependency track list of projects
+name: Dependency Track
+
+
+on:
+  workflow_dispatch:
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+
+    - name: Query from DT
+      env:
+        DEPENDENCY_TRACK_API_KEY: ${{ secrets.DEP_TRACK_TOKEN }}
+      run: |
+        curl -H "X-Api-Key: $DEPENDENCY_TRACK_API_KEY" https://sbom.eclipse.org/dashboard:8081/api/v1/project
+
+


### PR DESCRIPTION
Workflow to query from the dependency track instance to get the list of projects, using the read-only token.